### PR TITLE
Improve OpenAI key diagnostics and add verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Create a `.env.local` file in the project root with your OpenAI credentials:
 OPENAI_API_KEY=your_openai_api_key
 ```
 
+To verify that the key is valid and that your account has access to the required models, run:
+
+```bash
+npm run check-key
+```
+
+The script performs a lightweight request to the OpenAI API and prints either a confirmation message or details about why the key was rejected (for example, a `401` if the key is invalid or lacks access).
+
 ### Running Locally
 ```bash
 npm run dev

--- a/app/api/generate-audio/route.ts
+++ b/app/api/generate-audio/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
 
+import { extractOpenAIError } from "../../../../lib/openaiError";
+
 export async function POST(request: Request) {
   try {
     const { text } = await request.json();
@@ -45,9 +47,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ url: audioUrl });
   } catch (error) {
     console.error("[generate-audio] error:", error);
+
+    const { status, message } = extractOpenAIError(error);
+
     return NextResponse.json(
-      { error: "An error occurred while generating the audio." },
-      { status: 500 }
+      { error: message },
+      { status: status ?? 500 }
     );
   }
 }

--- a/app/api/generate-video/route.ts
+++ b/app/api/generate-video/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
 
+import { extractOpenAIError } from "../../../../lib/openaiError";
+
 type SoraVideoResponse = {
   data?: Array<{ url?: string | null } | null> | null;
   url?: string | null;
@@ -63,9 +65,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ url: videoUrl });
   } catch (error) {
     console.error("[generate-video] error:", error);
+
+    const { status, message } = extractOpenAIError(error);
+
     return NextResponse.json(
-      { error: "An error occurred while generating the video." },
-      { status: 500 }
+      {
+        error: message,
+      },
+      { status: status ?? 500 }
     );
   }
 }

--- a/lib/openaiError.ts
+++ b/lib/openaiError.ts
@@ -1,0 +1,41 @@
+export type OpenAIErrorPayload = {
+  status?: number;
+  message?: string;
+  error?: {
+    message?: string;
+    type?: string;
+  };
+};
+
+export function extractOpenAIError(error: unknown): {
+  status?: number;
+  message: string;
+} {
+  if (typeof error === "object" && error !== null) {
+    const payload = error as OpenAIErrorPayload;
+    const status = typeof payload.status === "number" ? payload.status : undefined;
+    const detailedMessage =
+      payload.error?.message ??
+      (typeof payload.message === "string" ? payload.message : undefined);
+
+    if (status === 401) {
+      return {
+        status,
+        message:
+          "OpenAI rejected the request with status 401. Confirm that OPENAI_API_KEY is correct and has access to the required models.",
+      };
+    }
+
+    if (detailedMessage) {
+      return {
+        status,
+        message: detailedMessage,
+      };
+    }
+  }
+
+  return {
+    status: undefined,
+    message: "An unexpected error occurred while communicating with OpenAI.",
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "autoprefixer": "^10.4.17",
+        "dotenv": "^16.4.5",
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.3",
         "postcss": "^8.4.35",
@@ -2044,6 +2045,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "check-key": "node scripts/check-openai-key.mjs"
   },
   "dependencies": {
     "axios": "^1.6.8",
@@ -25,6 +26,7 @@
     "eslint-config-next": "^14.2.3",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.3",
+    "dotenv": "^16.4.5",
     "typescript": "^5.4.5"
   }
 }

--- a/scripts/check-openai-key.mjs
+++ b/scripts/check-openai-key.mjs
@@ -1,0 +1,45 @@
+import { config } from "dotenv";
+import OpenAI from "openai";
+
+config({ path: ".env.local" });
+
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  console.error("❌ OPENAI_API_KEY is missing. Add it to your .env.local file.");
+  process.exit(1);
+}
+
+const client = new OpenAI({ apiKey });
+
+async function main() {
+  try {
+    const response = await client.models.list({ limit: 1 });
+    const firstModel = response.data?.[0]?.id;
+
+    console.log("✅ Successfully contacted OpenAI.");
+    if (firstModel) {
+      console.log(`First available model: ${firstModel}`);
+    }
+  } catch (error) {
+    const status = typeof error?.status === "number" ? error.status : undefined;
+    const message =
+      error?.error?.message ??
+      error?.message ??
+      "OpenAI returned an unknown error while verifying the API key.";
+
+    if (status === 401) {
+      console.error(
+        "❌ OpenAI rejected the request with status 401. Double-check your OPENAI_API_KEY and account access."
+      );
+    } else {
+      console.error("❌ Failed to verify the OpenAI API key.");
+    }
+
+    console.error(`Status: ${status ?? "unknown"}`);
+    console.error(`Message: ${message}`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a reusable helper to extract OpenAI error details and surface clearer responses
- add a script and documentation to verify the configured OpenAI API key
- wire the new error handling into the audio and video generation routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e637400aa4832eaeeb56154dffec4a